### PR TITLE
Update S3 deployment glob pattern to correctly exclude all files

### DIFF
--- a/packages/@aws-cdk/aws-s3-deployment/README.md
+++ b/packages/@aws-cdk/aws-s3-deployment/README.md
@@ -91,7 +91,7 @@ new BucketDeployment(this, 'BucketDeployment', {
 });
 
 new BucketDeployment(this, 'HTMLBucketDeployment', {
-  sources: [Source.asset('./website', { exclude: ['!index.html'] })],
+  sources: [Source.asset('./website', { exclude: ['*', '!index.html'] })],
   destinationBucket: bucket,
   cacheControl: [CacheControl.fromString('max-age=0,no-cache,no-store,must-revalidate')],
   prune: false,


### PR DESCRIPTION
According to https://github.com/aws/aws-cdk/issues/9146#issuecomment-660469797, an exclude 
pattern should be preceded by a `'*'` glob pattern, for it to take the desired effect that is mentioned 
in the documentation (to only include the `index.html` file).


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
